### PR TITLE
Update Docs for Local Routing

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -110,6 +110,12 @@ Running your functions locally for testing and debugging is easy to do with gobl
 Then run ``goblet local test`` and replace test with whatever variable you decide to use.
 Now you can hit your functions endpoint at ``localhost:8080``.
 
+To test a route locally make sure to add the header ``X-Envoy-Original-Path``. Otherwise the route will default to ``http()``
+
+.. code:: sh 
+
+    curl -H X-Envoy-Original-Path:true  localhost:8080/endpoint
+
 To test a scheduled job locally you will need to include two headers in your request. One ``X-Goblet-Type:schedule`` and 
 ``X-Goblet-Name:FUNCTION_NAME`` which is the name of your function.
 
@@ -275,8 +281,7 @@ If you use a custom schema type you should create a schema class that inherits f
 
     # custom responses and request_types
     # Request body must be schema defition valid with openapi spec 2
-    @app.route('/custom', request_body={'schema': {"type": "array", "items": {'type': 'string'}}}),
-    responses={'400': {'description': '400'}})
+    @app.route('/custom', request_body={'schema': {"type": "array", "items": {'type': 'string'}}}, responses={'400': {'description': '400'}})
     def custom():
         request = app.current_request
         assert request.data ["string1", "string2"]


### PR DESCRIPTION
With latest changes to `routes` local requests now need require header `X-Envoy-Original-Path` 