### PR TITLE
Http Header Filters

### DIFF
--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -4,7 +4,7 @@ Resources
 
 Http
 ^^^^
-You can have one http endpoint that can be triggered by calling the cloudfunction directly. This is the simpliest endpoint and will
+You can have a http endpoint that can be triggered by calling the cloudfunction directly. This is the simpliest endpoint and will
 only deploy a cloudfunction. The function takes in a flask request object
 
 .. code:: python 
@@ -16,6 +16,31 @@ only deploy a cloudfunction. The function takes in a flask request object
     @app.http()
     def http_entrypoint(request):
         return request.json
+
+
+You can have multiple http endpoints that get triggered based on the request headers. Note if multiple header filters match, only the first match will be 
+triggered.
+
+
+The following endpoint will be triggered on any request that has a "X-Github-Event" header
+
+.. code:: python 
+
+    @app.http(headers={"X-Github-Event"})
+    def main(request):
+        return jsonify(request.json)
+
+The following endpoints will be triggered if the request contains a "X-Github-Event" header that matches the corresponding value
+
+.. code:: python 
+
+    @app.http(headers={"X-Github-Event": "issue"})
+    def main(request):
+        return jsonify("triggered on issue")
+
+    @app.http(headers={"X-Github-Event": "pr"})
+        def main(request):
+            return jsonify("triggered on pr")
 
 Routes
 ^^^^^^

--- a/examples/main.py
+++ b/examples/main.py
@@ -12,6 +12,16 @@ from marshmallow import Schema, fields
 def main(request):
     return jsonify(request.json)
 
+# Example http trigger that contains header
+@app.http(headers={"X-Github-Event"})
+def main(request):
+    return jsonify(request.json)
+
+# Example http triggers that matches header
+@app.http(headers={"X-Github-Event": "issue"})
+def main(request):
+    return jsonify(request.json)
+
 # path param
 @app.route('/home/{test}')
 def home(test):

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -54,7 +54,7 @@ class DecoratorAPI:
             registration_kwargs={'bucket': bucket, 'event_type': event_type},
         )
 
-    def http(self, headers={}):
+    def http(self, headers):
         """Base http trigger"""
         return self._create_registration_function(
             handler_type='http',
@@ -176,7 +176,7 @@ class Register_Handlers(DecoratorAPI):
         self.middleware_handlers[event_type] = middleware_list
 
     def _register_http(self, name, func, kwargs):
-        self.handlers["http"].register_http(func=func, kwargs=kwargs)
+        self.handlers["http"].register_http(func, kwargs=kwargs)
 
     def _register_route(self, name, func, kwargs):
         self.handlers["route"].register_route(name=name, func=func, kwargs=kwargs)

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -54,10 +54,11 @@ class DecoratorAPI:
             registration_kwargs={'bucket': bucket, 'event_type': event_type},
         )
 
-    def http(self):
+    def http(self, headers={}):
         """Base http trigger"""
         return self._create_registration_function(
-            handler_type='http'
+            handler_type='http',
+            registration_kwargs={'headers': headers},
         )
 
     def _create_registration_function(self, handler_type,
@@ -175,7 +176,7 @@ class Register_Handlers(DecoratorAPI):
         self.middleware_handlers[event_type] = middleware_list
 
     def _register_http(self, name, func, kwargs):
-        self.handlers["http"].register_http(func)
+        self.handlers["http"].register_http(func=func, kwargs=kwargs)
 
     def _register_route(self, name, func, kwargs):
         self.handlers["route"].register_route(name=name, func=func, kwargs=kwargs)

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -54,7 +54,7 @@ class DecoratorAPI:
             registration_kwargs={'bucket': bucket, 'event_type': event_type},
         )
 
-    def http(self, headers):
+    def http(self, headers={}):
         """Base http trigger"""
         return self._create_registration_function(
             handler_type='http',

--- a/goblet/resources/http.py
+++ b/goblet/resources/http.py
@@ -4,17 +4,23 @@ from goblet.handler import Handler
 class HTTP(Handler):
     """Http Trigger"""
     def __init__(self, http=None):
-        self.http = http
+        self.http = http or []
 
-    def register_http(self, func):
-        self.http = func
+    def register_http(self, func, kwargs):
+        self.http.append({"func": func, "headers": kwargs.get("headers", {})})
 
     def __call__(self, request, context=None):
-        return self.http(request)
+        headers = request.headers or {}
+        for http_endpoint in self.http:
+            endpoint_headers = http_endpoint["headers"]
+            if isinstance(endpoint_headers, dict) and endpoint_headers.items() <= headers.items():
+                return http_endpoint["func"](request)
+            if isinstance(endpoint_headers, set) and endpoint_headers <= headers.keys():
+                return http_endpoint["func"](request)
 
     def __add__(self, other):
         if other.http:
-            self.http = other.http
+            self.http.extend(other.http)
         return self
 
     def deploy(self, sourceUrl=None, entrypoint=None):

--- a/goblet/tests/test_http.py
+++ b/goblet/tests/test_http.py
@@ -21,3 +21,52 @@ class TestHttp():
         app(mock_request, None)
 
         assert(mock.call_count == 1)
+
+    def test_call_headers_dict(self):
+        app = Goblet(function_name="goblet_example")
+        mock = Mock()
+
+        @app.http(headers={"test": 1})
+        def mock_function(request):
+            mock()
+            return True
+
+        mock_request = Mock()
+        mock_request.path = '/'
+        mock_request.headers = {"test": 1}
+
+        mock_request2 = Mock()
+        mock_request2.path = '/'
+        mock_request2.headers = {"test": 2}
+
+        app(mock_request, None)
+        app(mock_request2, None)
+
+        assert(mock.call_count == 1)
+
+    def test_call_headers_set(self):
+        app = Goblet(function_name="goblet_example")
+        mock = Mock()
+
+        @app.http(headers={"test"})
+        def mock_function(request):
+            mock()
+            return True
+
+        mock_request = Mock()
+        mock_request.path = '/'
+        mock_request.headers = {"test": 1}
+
+        mock_request2 = Mock()
+        mock_request2.path = '/'
+        mock_request2.headers = {"test": 2}
+
+        mock_request3 = Mock()
+        mock_request3.path = '/'
+        mock_request3.headers = {}
+
+        app(mock_request, None)
+        app(mock_request2, None)
+        app(mock_request3, None)
+
+        assert(mock.call_count == 2)

--- a/goblet/tests/test_http.py
+++ b/goblet/tests/test_http.py
@@ -26,14 +26,41 @@ class TestHttp():
         app = Goblet(function_name="goblet_example")
         mock = Mock()
 
-        @app.http(headers={"test": 1})
+        @app.http(headers={"test": 1, "test2": 2})
         def mock_function(request):
             mock()
             return True
 
         mock_request = Mock()
         mock_request.path = '/'
-        mock_request.headers = {"test": 1}
+        mock_request.headers = {"test": 1, "test2": 2}
+
+        mock_request2 = Mock()
+        mock_request2.path = '/'
+        mock_request2.headers = {"test": 1}
+
+        mock_request3 = Mock()
+        mock_request3.path = '/'
+        mock_request3.headers = {"test": 3}
+
+        app(mock_request, None)
+        app(mock_request2, None)
+        app(mock_request3, None)
+
+        assert(mock.call_count == 1)
+
+    def test_call_headers_set(self):
+        app = Goblet(function_name="goblet_example")
+        mock = Mock()
+
+        @app.http(headers={"test", "also_test"})
+        def mock_function(request):
+            mock()
+            return True
+
+        mock_request = Mock()
+        mock_request.path = '/'
+        mock_request.headers = {"test": 1, "also_test": 1}
 
         mock_request2 = Mock()
         mock_request2.path = '/'
@@ -43,30 +70,3 @@ class TestHttp():
         app(mock_request2, None)
 
         assert(mock.call_count == 1)
-
-    def test_call_headers_set(self):
-        app = Goblet(function_name="goblet_example")
-        mock = Mock()
-
-        @app.http(headers={"test"})
-        def mock_function(request):
-            mock()
-            return True
-
-        mock_request = Mock()
-        mock_request.path = '/'
-        mock_request.headers = {"test": 1}
-
-        mock_request2 = Mock()
-        mock_request2.path = '/'
-        mock_request2.headers = {"test": 2}
-
-        mock_request3 = Mock()
-        mock_request3.path = '/'
-        mock_request3.headers = {}
-
-        app(mock_request, None)
-        app(mock_request2, None)
-        app(mock_request3, None)
-
-        assert(mock.call_count == 2)


### PR DESCRIPTION
Adds option to supply headers in the http endpoint to trigger different endpoints based on their headers. (closes #50 )

handles sets which triggers if that header is contained in the request
```
@app.http(headers={"X-GitHub-Event"})
def github(request):
   return  issues + prs
```

handles dictionaries which triggers if the header and corresponding value is contained in the request

```
@app.http(headers={"X-GitHub-Event":"issues"})
def issues(request):
   return issues

@app.http(headers={"X-GitHub-Event":"pull_requests"})
def prs(request):
   return prs
```