### PR TITLE
apiConfig options and Security Section in OpenApiSpec

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -94,7 +94,7 @@ Example config.json:
 
 .. _GLOB: https://docs.python.org/3/library/glob.html
 
-You can customize the configs for an Api Gateway using the `apiGateway` key in `config.json`. Allowed fields can be found 
+You can customize the configs for an Api Gateway using the `apiConfig` key in `config.json`. Allowed fields can be found 
 `here <https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations.apis.configs#ApiConfig>`_ and include 
 
 * gatewayServiceAccount
@@ -104,8 +104,8 @@ You can customize the configs for an Api Gateway using the `apiGateway` key in `
 .. code:: json
 
     {
-        "apiGateway": {
-            "gatewayServiceAccount": ServiceAccount@PROJECT,
+        "apiConfig": {
+            "gatewayServiceAccount": "projects/-/serviceAccounts/ServiceAccount@PROJECT",
             "labels": {
                 "label1" : "value1"
             }

--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -94,6 +94,23 @@ Example config.json:
 
 .. _GLOB: https://docs.python.org/3/library/glob.html
 
+You can customize the configs for an Api Gateway using the `apiGateway` key in `config.json`. Allowed fields can be found 
+`here <https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations.apis.configs#ApiConfig>`_ and include 
+
+* gatewayServiceAccount
+* labels 
+* displayName
+
+.. code:: json
+
+    {
+        "apiGateway": {
+            "gatewayServiceAccount": ServiceAccount@PROJECT,
+            "labels": {
+                "label1" : "value1"
+            }
+        }
+    }  
 
 Iam Bindings
 ^^^^^^^^^^^^
@@ -213,6 +230,22 @@ An api using JWT authentication would require the following in ``config.json``
             }
         }
     }
+
+This generates a `security section <https://swagger.io/docs/specification/2-0/authentication/>`_ in the openapi 
+spec with empty scopes. If you would like to customize the security section and add custom scopes use the `security` 
+section in `config.json`
+
+
+.. code:: json
+
+    {
+        "security":[
+            {
+                "OAuth2": ["read", "write"]
+            }
+        ]
+    }
+
 
 Request
 ^^^^^^^

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -230,7 +230,7 @@ class OpenApiSpec:
         }
         if security_definitions:
             self.spec["securityDefinitions"] = security_definitions
-            self.spec["security"] = security or list(map(lambda s: {s:[]}, security_definitions))
+            self.spec["security"] = security or list(map(lambda s: {s: []}, security_definitions))
         self.spec["schemes"] = ["https"]
         self.spec['produces'] = ["application/json"]
         self.spec["paths"] = {}

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -59,8 +59,7 @@ class TestOpenApiSpec:
         }
         spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def)
         assert(spec.spec["securityDefinitions"] == security_def)
-        assert(spec.spec["security"] == [{"your_custom_auth_id":[]}])
-
+        assert(spec.spec["security"] == [{"your_custom_auth_id": []}])
 
     def test_security_config(self):
         security_def = {
@@ -72,9 +71,9 @@ class TestOpenApiSpec:
                 "x-google-jwks_uri": "url to the public key"
             }
         }
-        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def,security=[{"custom":[]}])
+        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def, security=[{"custom": []}])
         assert(spec.spec["securityDefinitions"] == security_def)
-        assert(spec.spec["security"] == [{"custom":[]}])
+        assert(spec.spec["security"] == [{"custom": []}])
 
     def test_add_primitive_types(self):
         def prim_typed(param: str, param2: bool) -> int:

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -59,6 +59,22 @@ class TestOpenApiSpec:
         }
         spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def)
         assert(spec.spec["securityDefinitions"] == security_def)
+        assert(spec.spec["security"] == [{"your_custom_auth_id":[]}])
+
+
+    def test_security_config(self):
+        security_def = {
+            "your_custom_auth_id": {
+                "authorizationUrl": "",
+                "flow": "implicit",
+                "type": "oauth2",
+                "x-google-issuer": "issuer of the token",
+                "x-google-jwks_uri": "url to the public key"
+            }
+        }
+        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def,security=[{"custom":[]}])
+        assert(spec.spec["securityDefinitions"] == security_def)
+        assert(spec.spec["security"] == [{"custom":[]}])
 
     def test_add_primitive_types(self):
         def prim_typed(param: str, param2: bool) -> int:


### PR DESCRIPTION
* Ability to configure apiSpec using `config.json`, which included gatewayServiceAccount (closes #71)
```
    {
        "apiConfig": {
            "gatewayServiceAccount": "projects/-/serviceAccounts/ServiceAccount@PROJECT",
            "labels": {
                "label1" : "value1"
            }
        }
    }  
```
* Add security section to openApispec based on securityDefinitions or `security` field in `config.json` (closes #72 )