### PR TITLE
CORS

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -472,3 +472,31 @@ cloudfunction, specify the endpoint in the `backend` argment in `route`. Note th
     @app.route('/custom_backend', backend="https://www.CLOUDRUN_URL.com/home")
     def home():
         return 
+
+Cors
+^^^^
+
+Cors can be set on the route level or on the Goblet application level. Setting `cors=True` uses the default cors setting 
+
+.. code:: json 
+
+    headers : {
+        "Access-Control-Allow-Headers" : ['Content-Type', 'Authorization'],
+        "Access-Control-Allow-Origin": "*"
+    }
+
+.. code:: python 
+
+    @app.route('/custom_backend', cors=True)
+    def home():
+        return "cors headers"
+
+Use the `CORSConfig` class to set customized cors headers from the `goblet.resources.routes` class. 
+
+.. code:: python 
+
+    from goblet.resources.routes import CORSConfig
+
+    @app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost'))
+    def custom_cors():
+        return jsonify('localhost is allowed')

--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -94,6 +94,23 @@ Example config.json:
 
 .. _GLOB: https://docs.python.org/3/library/glob.html
 
+You can customize the configs for an Api Gateway using the `apiGateway` key in `config.json`. Allowed fields can be found 
+`here <https://cloud.google.com/api-gateway/docs/reference/rest/v1/projects.locations.apis.configs#ApiConfig>`_ and include 
+
+* gatewayServiceAccount
+* labels 
+* displayName
+
+.. code:: json
+
+    {
+        "apiGateway": {
+            "gatewayServiceAccount": ServiceAccount@PROJECT,
+            "labels": {
+                "label1" : "value1"
+            }
+        }
+    }  
 
 Iam Bindings
 ^^^^^^^^^^^^
@@ -213,6 +230,22 @@ An api using JWT authentication would require the following in ``config.json``
             }
         }
     }
+
+This generates a `security section <https://swagger.io/docs/specification/2-0/authentication/>`_ in the openapi 
+spec with empty scopes. If you would like to customize the security section and add custom scopes use the `security` 
+section in `config.json`
+
+
+.. code:: json
+
+    {
+        "security":[
+            {
+                "OAuth2": ["read", "write"]
+            }
+        ]
+    }
+
 
 Request
 ^^^^^^^

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -13,9 +13,9 @@ class Goblet(Register_Handlers):
     Main class which inherits most of its logic from the Register_Handlers class. Local param is used
     to set the entrypoint for running goblet locally
     """
-    def __init__(self, function_name="goblet", local=None):
+    def __init__(self, function_name="goblet", local=None, cors=None):
         self.function_name = GConfig().function_name or function_name
-        super(Goblet, self).__init__(function_name=self.function_name)
+        super(Goblet, self).__init__(function_name=self.function_name, cors=cors)
         self.log = logging.getLogger(__name__)
         self.headers = {}
         self.g = G()

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -82,9 +82,9 @@ class DecoratorAPI:
 class Register_Handlers(DecoratorAPI):
     """Core Goblet logic. App entrypoint is the __call__ function which routes the request to the corresonding handler class"""
 
-    def __init__(self, function_name):
+    def __init__(self, function_name, cors=None):
         self.handlers = {
-            "route": ApiGateway(function_name),
+            "route": ApiGateway(function_name, cors=cors),
             "schedule": Scheduler(function_name),
             "pubsub": PubSub(function_name),
             "storage": Storage(function_name),

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -230,7 +230,7 @@ class OpenApiSpec:
         }
         if security_definitions:
             self.spec["securityDefinitions"] = security_definitions
-            self.spec["security"] = security or list(map(lambda s: {s:[]}, security_definitions))
+            self.spec["security"] = security or list(map(lambda s: {s: []}, security_definitions))
         self.spec["schemes"] = ["https"]
         self.spec['produces'] = ["application/json"]
         self.spec["paths"] = {}

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -59,8 +59,7 @@ class TestOpenApiSpec:
         }
         spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def)
         assert(spec.spec["securityDefinitions"] == security_def)
-        assert(spec.spec["security"] == [{"your_custom_auth_id":[]}])
-
+        assert(spec.spec["security"] == [{"your_custom_auth_id": []}])
 
     def test_security_config(self):
         security_def = {
@@ -72,9 +71,9 @@ class TestOpenApiSpec:
                 "x-google-jwks_uri": "url to the public key"
             }
         }
-        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def,security=[{"custom":[]}])
+        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def, security=[{"custom": []}])
         assert(spec.spec["securityDefinitions"] == security_def)
-        assert(spec.spec["security"] == [{"custom":[]}])
+        assert(spec.spec["security"] == [{"custom": []}])
 
     def test_add_primitive_types(self):
         def prim_typed(param: str, param2: bool) -> int:

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -59,6 +59,22 @@ class TestOpenApiSpec:
         }
         spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def)
         assert(spec.spec["securityDefinitions"] == security_def)
+        assert(spec.spec["security"] == [{"your_custom_auth_id":[]}])
+
+
+    def test_security_config(self):
+        security_def = {
+            "your_custom_auth_id": {
+                "authorizationUrl": "",
+                "flow": "implicit",
+                "type": "oauth2",
+                "x-google-issuer": "issuer of the token",
+                "x-google-jwks_uri": "url to the public key"
+            }
+        }
+        spec = OpenApiSpec("test", "xyz.cloudfunction", security_definitions=security_def,security=[{"custom":[]}])
+        assert(spec.spec["securityDefinitions"] == security_def)
+        assert(spec.spec["security"] == [{"custom":[]}])
 
     def test_add_primitive_types(self):
         def prim_typed(param: str, param2: bool) -> int:

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
-from goblet import Goblet
-from goblet.resources.routes import ApiGateway
+from goblet import Goblet, Response, jsonify
+from goblet.resources.routes import ApiGateway, CORSConfig
 from goblet.deploy import Deployer
 from goblet.test_utils import get_responses, get_response, dummy_function, mock_dummy_function
 
@@ -77,17 +77,59 @@ class TestRoutes:
         mock_event1 = Mock()
         mock_event1.path = '/test'
         mock_event1.method = 'GET'
-        mock_event1.headers = {"X-Envoy-Original-Path": True}
         app(mock_event1, None)
 
         mock_event2 = Mock()
         mock_event2.path = '/test/param'
         mock_event2.method = 'POST'
-        mock_event2.headers = {"X-Envoy-Original-Path": True}
         app(mock_event2, None)
 
         assert(mock.call_count == 1)
         mock_param.assert_called_once_with('param')
+
+    def test_cors(self):
+        app = Goblet(function_name="goblet_cors")
+        app2 = Goblet(function_name="goblet_cors", cors=CORSConfig(allow_origin='app-level'))
+
+        @app.route('/test', cors=True)
+        def mock_function():
+            return '200'
+
+        @app2.route('/test2')
+        def mock_function2():
+            return Response('200')
+
+        @app2.route('/override', cors=CORSConfig(allow_origin='override'))
+        def mock_function_override():
+            return Response('200')
+
+        @app.route('/test3', cors=CORSConfig(allow_origin='localhost'))
+        def mock_function3():
+            return jsonify('200')
+
+        mock_event1 = Mock()
+        mock_event1.path = '/test'
+        mock_event1.method = 'GET'
+        resp = app(mock_event1, None)
+        assert(resp.headers['Access-Control-Allow-Origin'] == "*")
+
+        mock_event2 = Mock()
+        mock_event2.path = '/test2'
+        mock_event2.method = 'GET'
+        resp2 = app2(mock_event2, None)
+        assert(resp2.headers['Access-Control-Allow-Origin'] == 'app-level')
+
+        mock_event_override = Mock()
+        mock_event_override.path = '/override'
+        mock_event_override.method = 'GET'
+        resp2 = app2(mock_event_override, None)
+        assert(resp2.headers['Access-Control-Allow-Origin'] == 'override')
+
+        mock_event3 = Mock()
+        mock_event3.path = '/test3'
+        mock_event3.method = 'GET'
+        resp3 = app(mock_event3, None)
+        assert(resp3[2]['Access-Control-Allow-Origin'] == 'localhost')
 
     def test_deploy_routes(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")


### PR DESCRIPTION
Cors can be set on the route level or on the Goblet application level. Setting `cors=True` uses the default cors setting. (closes #60 )

```
app=goblet("example",cors=True)
```
or

```   
    @app.route('/custom_backend', cors=True)
    def home():
        return "cors headers"
```

results in these headers 
```
    headers : {
        "Access-Control-Allow-Headers" : ['Content-Type', 'Authorization'],
        "Access-Control-Allow-Origin": "*"
    }
```
Use the `CORSConfig` class to set customized cors headers from the `goblet.resources.routes` class. 

```
    from goblet.resources.routes import CORSConfig
    @app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost'))
    def custom_cors():
        return jsonify('localhost is allowed')
```