### PR TITLE
Scheduler Enhancements

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Blogs
    blogs
 
 Integrations
---------
+------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -106,6 +106,18 @@ Example usage:
     def scheduled_job():
         return app.jsonify("success")
 
+You can pass in additional fields to your schedule to add custom headers, body, and method using the types defines for `httpTarget <https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs#HttpTarget>`__.
+
+.. code:: python 
+
+    @app.schedule('5 * * * *', headers={"x-cron": "5 * * * *"}, body="a base64-encoded string")
+    @app.schedule('6 * * * *', headers={"x-cron": "6 * * * *"}, body="another base64-encoded string")
+    @app.schedule('10 * * * *', httpMethod="POST")
+    def scheduled_job():
+        app.current_request.body
+        app.current_request.headers
+        return app.jsonify("success")
+
 
 .. _HERE: https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules
 .. _CLOUD SCHEDULER: https://cloud.google.com/scheduler

--- a/examples/main.py
+++ b/examples/main.py
@@ -84,6 +84,14 @@ def response():
 def scheduled_job():
     return jsonify("success")
 
+# Scheduled job with custom headers, method, and body
+@app.schedule('5 * * * *', httpMethod='POST', headers={'X-Custom': 'header'}, body='BASE64 ENCODED STRING')
+def scheduled_job():
+    headers = app.current_request.headers
+    body = app.current_request.body
+    method = app.current_request.method
+    return jsonify("success")
+
 # Pubsub topic
 @app.topic('test')
 def topic(data):

--- a/goblet/resources/scheduler.py
+++ b/goblet/resources/scheduler.py
@@ -32,7 +32,17 @@ class Scheduler(Handler):
         kwargs = kwargs.pop('kwargs')
         timezone = kwargs.get("timezone", 'UTC')
         description = kwargs.get("description", "Created by goblet")
+        headers = kwargs.get("headers", {})
+        httpMethod = kwargs.get("httpMethod", "GET")
+        body = kwargs.get("body")
+        job_num = 1
+        if self.jobs.get(name):
+            # increment job_num if there is already a scheduled job for this func
+            job_num = self.jobs[name]["job_num"] + 1
+            self.jobs[name]["job_num"] = job_num
+            name = f"{name}-{job_num}"
         self.jobs[name] = {
+            "job_num": job_num,
             "job_json": {
                 "name": f"projects/{get_default_project()}/locations/{get_default_location()}/jobs/{self.name}-{name}",
                 "schedule": schedule,
@@ -42,9 +52,11 @@ class Scheduler(Handler):
                     # "uri": ADDED AT runtime,
                     "headers": {
                         'X-Goblet-Type': 'schedule',
-                        'X-Goblet-Name': name
+                        'X-Goblet-Name': name,
+                        **headers
                     },
-                    "httpMethod": "GET",
+                    "body": body,
+                    "httpMethod": httpMethod,
                     'oidcToken': {
                         # "serviceAccountEmail": ADDED AT runtime
                     }

--- a/goblet/tests/data/http/schedule-deploy-multiple/get-v1-projects-goblet-locations-us-central1-functions-goblet-test-schedule_1.json
+++ b/goblet/tests/data/http/schedule-deploy-multiple/get-v1-projects-goblet-locations-us-central1-functions-goblet-test-schedule_1.json
@@ -1,0 +1,35 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 02 Nov 2021 14:45:13 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "921",
+    "-content-encoding": "gzip",
+    "content-location": "https://cloudfunctions.googleapis.com/v1/projects/goblet/locations/us-central1/functions/goblet-test-schedule?alt=json"
+  },
+  "body": {
+    "name": "projects/goblet/locations/us-central1/functions/goblet-test-schedule",
+    "description": "created by goblet",
+    "httpsTrigger": {
+      "url": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule",
+      "securityLevel": "SECURE_OPTIONAL"
+    },
+    "status": "ACTIVE",
+    "entryPoint": "goblet_entrypoint",
+    "timeout": "60s",
+    "availableMemoryMb": 256,
+    "serviceAccountEmail": "goblet@appspot.gserviceaccount.com",
+    "updateTime": "2021-11-02T14:30:56.223Z",
+    "versionId": "6",
+    "runtime": "python37",
+    "ingressSettings": "ALLOW_ALL"
+  }
+}

--- a/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_1.json
+++ b/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_1.json
@@ -1,0 +1,39 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 02 Nov 2021 14:45:14 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "777",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/goblet/locations/us-central1/jobs/goblet-test-schedule-test-job",
+    "description": "Created by goblet",
+    "httpTarget": {
+      "uri": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule",
+      "httpMethod": "GET",
+      "headers": {
+        "User-Agent": "Google-Cloud-Scheduler",
+        "X-Goblet-Type": "schedule",
+        "X-Goblet-Name": "test-job"
+      },
+      "oidcToken": {
+        "serviceAccountEmail": "goblet@appspot.gserviceaccount.com",
+        "audience": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule"
+      }
+    },
+    "userUpdateTime": "2021-11-02T14:45:14Z",
+    "state": "ENABLED",
+    "schedule": "* * 1 * *",
+    "timeZone": "UTC",
+    "attemptDeadline": "180s"
+  }
+}

--- a/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_2.json
+++ b/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_2.json
@@ -1,0 +1,39 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 02 Nov 2021 14:45:15 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "782",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/goblet/locations/us-central1/jobs/goblet-test-schedule-test-job-2",
+    "description": "Created by goblet",
+    "httpTarget": {
+      "uri": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule",
+      "httpMethod": "POST",
+      "headers": {
+        "X-Goblet-Name": "test-job-2",
+        "User-Agent": "Google-Cloud-Scheduler",
+        "X-Goblet-Type": "schedule"
+      },
+      "oidcToken": {
+        "serviceAccountEmail": "goblet@appspot.gserviceaccount.com",
+        "audience": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule"
+      }
+    },
+    "userUpdateTime": "2021-11-02T14:45:15Z",
+    "state": "ENABLED",
+    "schedule": "* * 2 * *",
+    "timeZone": "UTC",
+    "attemptDeadline": "180s"
+  }
+}

--- a/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_3.json
+++ b/goblet/tests/data/http/schedule-deploy-multiple/post-v1-projects-goblet-locations-us-central1-jobs_3.json
@@ -1,0 +1,40 @@
+{
+  "headers": {
+    "content-type": "application/json; charset=UTF-8",
+    "vary": "Origin, X-Origin, Referer",
+    "date": "Tue, 02 Nov 2021 14:45:16 GMT",
+    "server": "ESF",
+    "cache-control": "private",
+    "x-xss-protection": "0",
+    "x-frame-options": "SAMEORIGIN",
+    "x-content-type-options": "nosniff",
+    "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "809",
+    "-content-encoding": "gzip"
+  },
+  "body": {
+    "name": "projects/goblet/locations/us-central1/jobs/goblet-test-schedule-test-job-3",
+    "description": "Created by goblet",
+    "httpTarget": {
+      "uri": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule",
+      "httpMethod": "GET",
+      "headers": {
+        "X-HEADER": "header",
+        "User-Agent": "Google-Cloud-Scheduler",
+        "X-Goblet-Name": "test-job-3",
+        "X-Goblet-Type": "schedule"
+      },
+      "oidcToken": {
+        "serviceAccountEmail": "goblet@appspot.gserviceaccount.com",
+        "audience": "https://us-central1-goblet.cloudfunctions.net/goblet-test-schedule"
+      }
+    },
+    "userUpdateTime": "2021-11-02T14:45:16Z",
+    "state": "ENABLED",
+    "schedule": "* * 3 * *",
+    "timeZone": "UTC",
+    "attemptDeadline": "180s"
+  }
+}

--- a/goblet/tests/test_scheduler.py
+++ b/goblet/tests/test_scheduler.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 from goblet import Goblet
 from goblet.resources.scheduler import Scheduler
-from goblet.test_utils import get_responses, mock_dummy_function, dummy_function
+from goblet.test_utils import get_responses, get_response, mock_dummy_function, dummy_function
 
 
 class TestScheduler:
@@ -21,6 +21,7 @@ class TestScheduler:
             'timeZone': 'UTC',
             'description': 'test',
             'httpTarget': {
+                'body': None,
                 'headers': {
                     'X-Goblet-Type': 'schedule',
                     'X-Goblet-Name': 'dummy_function',
@@ -31,6 +32,38 @@ class TestScheduler:
         }
         assert(scheduler.jobs['dummy_function']['job_json'] == scheule_json)
         assert(scheduler.jobs['dummy_function']['func'] == dummy_function)
+
+    def test_multiple_schedules(self, monkeypatch):
+        app = Goblet(function_name="goblet_example")
+        monkeypatch.setenv("GOOGLE_PROJECT", "TEST_PROJECT")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+
+        app.schedule('1 * * * *', description='test')(dummy_function)
+        app.schedule('2 * * * *', headers={'test': 'header'})(dummy_function)
+        app.schedule('3 * * * *', httpMethod='POST')(dummy_function)
+
+        scheduler = app.handlers["schedule"]
+        assert(len(scheduler.jobs) == 3)
+        scheule_json = {
+            'name': 'projects/TEST_PROJECT/locations/us-central1/jobs/goblet_example-dummy_function',
+            'schedule': '1 * * * *',
+            'timeZone': 'UTC',
+            'description': 'test',
+            'httpTarget': {
+                'body': None,
+                'headers': {
+                    'X-Goblet-Type': 'schedule',
+                    'X-Goblet-Name': 'dummy_function',
+                },
+                'httpMethod': 'GET',
+                'oidcToken': {}
+            }
+        }
+        assert(scheduler.jobs['dummy_function']['job_json'] == scheule_json)
+        assert(scheduler.jobs['dummy_function-2']['job_json']['httpTarget']['headers']['test'] == 'header')
+        assert(scheduler.jobs['dummy_function-2']['job_json']['httpTarget']['headers']['X-Goblet-Name'] == 'dummy_function-2')
+        assert(scheduler.jobs['dummy_function-3']['job_json']['httpTarget']['headers']['X-Goblet-Name'] == 'dummy_function-3')
+        assert(scheduler.jobs['dummy_function-3']['job_json']['httpTarget']['httpMethod'] == 'POST')
 
     def test_call_scheduler(self, monkeypatch):
         app = Goblet(function_name="goblet_example")
@@ -71,6 +104,29 @@ class TestScheduler:
         assert(responses[1]['body']['httpTarget']['headers']['X-Goblet-Name'] == 'test-job')
         assert(responses[1]['body']['httpTarget']['headers']['X-Goblet-Type'] == 'schedule')
         assert(responses[1]['body']['schedule'] == '* * * * *')
+
+    def test_deploy_multiple_schedule(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("GOBLET_TEST_NAME", "schedule-deploy-multiple")
+        monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
+
+        goblet_name = 'goblet-test-schedule'
+        scheduler = Scheduler(goblet_name)
+        scheduler.register_job('test-job', None, kwargs={'schedule': '* * 1 * *', 'kwargs': {}})
+        scheduler.register_job('test-job', None, kwargs={'schedule': '* * 2 * *', 'kwargs': {'httpMethod': 'POST'}})
+        scheduler.register_job('test-job', None, kwargs={'schedule': '* * 3 * *', 'kwargs': {'headers': {'X-HEADER': 'header'}}})
+        scheduler.deploy()
+
+        post_job_1 = get_response('schedule-deploy-multiple', 'post-v1-projects-goblet-locations-us-central1-jobs_1.json')
+        post_job_2 = get_response('schedule-deploy-multiple', 'post-v1-projects-goblet-locations-us-central1-jobs_2.json')
+        post_job_3 = get_response('schedule-deploy-multiple', 'post-v1-projects-goblet-locations-us-central1-jobs_3.json')
+
+        assert(post_job_1['body']['httpTarget']['headers']['X-Goblet-Name'] == 'test-job')
+        assert(post_job_2['body']['httpTarget']['headers']['X-Goblet-Name'] == 'test-job-2')
+        assert(post_job_2['body']['httpTarget']['httpMethod'] == 'POST')
+        assert(post_job_3['body']['httpTarget']['headers']['X-Goblet-Name'] == 'test-job-3')
+        assert(post_job_3['body']['httpTarget']['headers']['X-HEADER'] == 'header')
 
     def test_destroy_schedule(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")


### PR DESCRIPTION
* multiple schedulers for one entry function
```
@app.schedule('5 * * * *')
@app.schedule('2 * * * *')
def scheduled_function()
   app.current_request
   return
```

* pass through custom scheduler params such as `body`, `headers`, `httpMethod`

```
@app.schedule('5 * * * *', httpMethod='POST', headers={'X-Custom': 'header'}, body='BASE64 ENCODED STRING')
@app.schedule('5 * * * *', httpMethod='GET', headers={'X-Custom': 'header2'}, body='BASE64 ENCODED STRING 2')
def scheduled_function()
   app.current_request
   return
```

closes #91 
