### PR TITLE
Fix function naming for storage triggered functions

### DIFF
--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -47,11 +47,11 @@ class DecoratorAPI:
             registration_kwargs={'topic': topic, 'kwargs': kwargs},
         )
 
-    def storage(self, bucket, event_type):
+    def storage(self, bucket, event_type, bucket_alias=None):
         """Storage event trigger"""
         return self._create_registration_function(
             handler_type='storage',
-            registration_kwargs={'bucket': bucket, 'event_type': event_type},
+            registration_kwargs={'bucket': bucket, 'event_type': event_type, 'bucket_alias': bucket_alias},
         )
 
     def http(self, headers={}):

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -47,11 +47,11 @@ class DecoratorAPI:
             registration_kwargs={'topic': topic, 'kwargs': kwargs},
         )
 
-    def storage(self, bucket, event_type, bucket_alias=None):
+    def storage(self, bucket, event_type, name=None):
         """Storage event trigger"""
         return self._create_registration_function(
             handler_type='storage',
-            registration_kwargs={'bucket': bucket, 'event_type': event_type, 'bucket_alias': bucket_alias},
+            registration_kwargs={'bucket': bucket, 'event_type': event_type, 'name': name},
         )
 
     def http(self, headers={}):
@@ -190,4 +190,5 @@ class Register_Handlers(DecoratorAPI):
         self.handlers["pubsub"].register_topic(name=name, func=func, kwargs=kwargs)
 
     def _register_storage(self, name, func, kwargs):
+        name = kwargs.get("name") or name
         self.handlers["storage"].register_bucket(name=name, func=func, kwargs=kwargs)

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -33,10 +33,12 @@ class Storage(Handler):
     def register_bucket(self, name, func, kwargs):
         bucket_name = kwargs["bucket"]
         event_type = kwargs["event_type"]
+        bucket_alias = kwargs.get("bucket_alias")
         self.validate_event_type(event_type)
         self.buckets.append({
             "bucket": bucket_name,
             "event_type": event_type,
+            "bucket_alias": bucket_alias,
             "name": name,
             "func": func
         })
@@ -66,7 +68,7 @@ class Storage(Handler):
         user_configs = config.cloudfunction or {}
         for bucket in self.buckets:
             req_body = {
-                "name": f"{self.cloudfunction}-storage-{bucket['event_type']}" if config.no_append_bucket else f"{self.cloudfunction}-storage-{bucket['bucket']}-{bucket['event_type']}".replace('.', '-'),
+                "name": f"{self.cloudfunction}-storage-{bucket['bucket_alias'] if bucket['bucket_alias'] else bucket['bucket']}-{bucket['event_type']}".replace('.', '-'),
                 "description": config.description or "created by goblet",
                 "entryPoint": entrypoint,
                 "sourceUploadUrl": sourceUrl,

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -83,4 +83,4 @@ class Storage(Handler):
 
     def destroy(self):
         for bucket in self.buckets:
-            destroy_cloudfunction(f"{self.name}-storage-{bucket['bucket']}-{bucket['event_type']}".replace('.', '-'))
+            destroy_cloudfunction(f"{self.name}-storage-{bucket['bucket_alias'] if bucket['bucket_alias'] else bucket['bucket']}-{bucket['event_type']}".replace('.', '-'))

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -66,7 +66,7 @@ class Storage(Handler):
         user_configs = config.cloudfunction or {}
         for bucket in self.buckets:
             req_body = {
-                "name": f"{self.cloudfunction}-storage-{bucket['bucket']}-{bucket['event_type']}",
+                "name": f"{self.cloudfunction}-storage-{bucket['event_type']}" if config.no_append_bucket else f"{self.cloudfunction}-storage-{bucket['bucket']}-{bucket['event_type']}".replace('.', '-'),
                 "description": config.description or "created by goblet",
                 "entryPoint": entrypoint,
                 "sourceUploadUrl": sourceUrl,
@@ -81,4 +81,4 @@ class Storage(Handler):
 
     def destroy(self):
         for bucket in self.buckets:
-            destroy_cloudfunction(f"{self.name}-storage-{bucket['bucket']}-{bucket['event_type']}")
+            destroy_cloudfunction(f"{self.name}-storage-{bucket['bucket']}-{bucket['event_type']}".replace('.', '-'))

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -33,7 +33,7 @@ class Storage(Handler):
     def register_bucket(self, name, func, kwargs):
         bucket_name = kwargs["bucket"]
         event_type = kwargs["event_type"]
-        bucket_alias = kwargs.get("bucket_alias")
+        bucket_alias = kwargs.get("name")
         self.validate_event_type(event_type)
         self.buckets.append({
             "bucket": bucket_name,


### PR DESCRIPTION
any `.` in the bucket name is now replaced with `-`
if `no_append_bucket` is set to `true` in the config, it will not add the bucket name to the function name