### PR TITLE
[Cloudfunction] Ability to import Private libraries 

### DIFF
--- a/goblet/__init__.py
+++ b/goblet/__init__.py
@@ -1,1 +1,1 @@
-from goblet.app import Goblet, jsonify, Response, goblet_entrypoint  # noqa: F401
+from goblet.app import Goblet, jsonify, Response, goblet_entrypoint, enable_gobletlib  # noqa: F401

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -2,6 +2,7 @@ from goblet.config import GConfig
 import logging
 import json
 import sys
+import os
 
 from goblet.decorators import Register_Handlers
 
@@ -85,3 +86,8 @@ def goblet_entrypoint(app, entrypoint="goblet_entrypoint"):
         def goblet_entrypoint_wrapper(request, context=None):
             return app(request, context)
         setattr(sys.modules['main'], entrypoint, goblet_entrypoint_wrapper)
+
+
+def enable_gobletlib():
+    current_path = os.path.realpath('.')
+    sys.path.append(f'{current_path}/gobletlib')

--- a/goblet/utils.py
+++ b/goblet/utils.py
@@ -114,3 +114,12 @@ def nested_update(d, u):
         else:
             d[k] = v
     return d
+
+
+def addFolderToZip(zip_file, folder):
+    for file in os.listdir(folder):
+        full_path = os.path.join(folder, file)
+        if os.path.isfile(full_path):
+            zip_file.write(full_path)
+        elif os.path.isdir(full_path):
+            addFolderToZip(zip_file, full_path)


### PR DESCRIPTION
specify private libraries in `goblet-requirements.txt` which are installed to gobletlib directory

run `enable_gobletlib` in order to use those libraries `import LIBRARY` or import directly via `import gobletlib.LIBRARY`

deletes the temp `gobletlib` folder after adding to zip package

closes (#108  )