### PR TITLE
Multi Cloudfunction Support

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -583,3 +583,38 @@ Use the `CORSConfig` class to set customized cors headers from the `goblet.resou
     @app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost'))
     def custom_cors():
         return jsonify('localhost is allowed')
+
+Multiple Cloudfunctions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Using the field `main_file` in `config.json` allows you to set any file as the entrypoint `main.py` file, which is required by cloudfunctions. 
+This allows for multiple functions to be deploying using similar code bases.
+
+For example with the following files which each contain a function and share code in `shared.py`
+
+`func1.py`
+`func2.py`
+
+Could have the goblet `.config`
+
+.. code: json 
+    {
+        "stages": {
+            "func1": {
+                "function_name": "func1",
+                "main_file" : "func1"
+
+            },
+            "func2": {
+                "function_name": "func2",
+                "main_file" : "func2"
+        }
+    }
+
+To test each function locally you can simply run `goblet local -s func1` and to deploy `goblet local -s func1 -p Project -l Region`
+
+Note: This may cause some imports to break if something is importing directly from the func1.py or func2.py since they will be renamed to `main.py` 
+in the packaged zipfile.
+
+Note: There is a bug when uploading a different `main_file`, while also having `main.py` in your code, so if you decide to use `main_file` remove `main.py`. The bug 
+shows the previos main.py in the gcp console, however the local zipfile and uploaded zipfile in gcs both contain the correct `main.py` 

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -19,12 +19,17 @@ class Goblet(Register_Handlers):
         self.log = logging.getLogger(__name__)
         self.headers = {}
         self.g = G()
-        if local and sys.modules.get('main'):
+
+        # Setup Local
+        module_name = GConfig().main_file or "main"
+        module_name = module_name.replace(".py", "")
+        if local and sys.modules.get(module_name):
             self.log = logging.getLogger('werkzeug')
 
             def local_func(request):
                 return self(request)
-            setattr(sys.modules['main'], local, local_func)
+
+            setattr(sys.modules[module_name], local, local_func)
 
 
 class Response(object):

--- a/goblet/deploy.py
+++ b/goblet/deploy.py
@@ -8,6 +8,7 @@ from requests import request
 import base64
 import json
 from urllib.parse import quote_plus
+import warnings
 
 from googleapiclient.errors import HttpError
 
@@ -135,12 +136,16 @@ class Deployer:
         """Zips requirements.txt, python files and any additional files based on config.customFiles"""
         config = GConfig()
         self.zip_file("requirements.txt")
+        if config.main_file:
+            self.zip_file(config.main_file, "main.py")
         include = config.customFiles or []
         include.append('*.py')
-        self.zip_directory(get_dir() + '/*', include=include)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.zip_directory(get_dir() + '/*', include=include)
 
-    def zip_file(self, filename):
-        self.zipf.write(filename)
+    def zip_file(self, filename, arcname=None):
+        self.zipf.write(filename, arcname)
 
     def zip_directory(self, dir, include=['*.py'], exclude=['build', 'docs', 'examples', 'test', 'venv']):
         exclusion_set = set(exclude)

--- a/goblet/utils.py
+++ b/goblet/utils.py
@@ -34,15 +34,15 @@ def get_app_from_module(m):
             return getattr(m, obj), obj
 
 
-def get_goblet_app():
-    """Look for main.py and return goblet app instance. Also sets the entrypoint for the app"""
+def get_goblet_app(main_file="main.py"):
+    """Look for main.py or main_file if defined and return goblet app instance."""
     dir_path = os.path.realpath('.')
-    spec = importlib.util.spec_from_file_location("main", f"{dir_path}/main.py")
+    spec = importlib.util.spec_from_file_location("main", f"{dir_path}/{main_file}")
     main = importlib.util.module_from_spec(spec)
     with add_to_path(dir_path):
         spec.loader.exec_module(main)
         app, app_name = get_app_from_module(main)
-    setattr(app, "entrypoint", app_name)
+    # setattr(app, "entrypoint", app_name)
     return app
 
 


### PR DESCRIPTION
Add `config` entry that allows any file to become the `main.py` file and therefore allow for multiple functions to be deploying using similar code bases. (#90 )

for example with the following files
```
func1.py
func2.py
shared.py
```

we could have the goblet `.config`
```
{
    "stages": {
        "func1": {
            "function_name": "func1",
            "main_file" : "func1.py"

        },
        "func2": {
            "function_name": "func2",
            "main_file" : "func2.py"
    }
}
```

Note this may cause some imports to break if something is importing from the `func1.py` or `func2.py` during runtime. 