### PR TITLE
Add Before and After Middleware handlers

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -642,3 +642,24 @@ The cli command `goblet sync` will sync resources that are deployed in GCP based
 convention that are no longer in the app configuration. For example schuduled jobs start with the function_name prefix so if the function_name is goblet_function
 the sync command will flag any scheduled jobs that start with the prefix `goblet_function` that are not in the current app config. Note this may cause some resources
 that are named similar to be deleted so make sure to run the command with `--dryrun` flag to see what resources are flagged for deletion.
+
+Middleware
+^^^^^^^^^^
+
+You can trigger custom middlware using the `before_request` and `after_request` decorators. These allow you to trigger custom functions before a request is passed to your request 
+handler or do post prosessing on your responses. 
+
+.. code: python
+
+    @app.before_request()
+    def add_db(request):
+        app.g.db = "db"
+        return request
+
+    @app.after_request(event_type="pubsub")
+    def add_header(response):
+        response.headers["X-Custom"] = "custom header"
+        return response
+
+You can have your middleware trigger only on certain event types using the `event_type` argument. Default is `all`. Possible 
+event types are `["all", "http", "schedule", "pubsub", "storage", "route"]`

--- a/examples/main.py
+++ b/examples/main.py
@@ -110,8 +110,14 @@ def storage(event):
     app.log.info(event)
     return 
 
-# Example middleware
-@app.middleware()
-def add_db(event):
+# Example before request
+@app.before_request()
+def add_db(request):
     app.g.db = "db"
-    return event
+    return request
+
+# Example after request
+@app.after_request()
+def add_header(response):
+    response.headers["X-Custom"] = "custom header"
+    return response

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -146,6 +146,9 @@ class Register_Handlers(DecoratorAPI):
         request = self._call_middleware(request, event_type, before_or_after="before")
         response = None
 
+        if event_type not in EVENT_TYPES:
+            raise ValueError(f"{event_type} not a valid event type")
+
         if event_type == "schedule":
             response = self.handlers["schedule"](request)
         if event_type == "pubsub":
@@ -156,9 +159,6 @@ class Register_Handlers(DecoratorAPI):
             response = self.handlers["route"](request)
         if event_type == "http":
             response = self.handlers["http"](request)
-
-        if not response:
-            raise ValueError(f"{event_type} not a valid event type")
 
         # call after request middleware
         response = self._call_middleware(response, event_type, before_or_after="after")

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -23,7 +23,7 @@ class DecoratorAPI:
 
         if event_type not in EVENT_TYPES:
             raise ValueError(f"{event_type} not in {EVENT_TYPES}")
-        
+
         def _middleware_wrapper(func):
             self.register_middleware(func, event_type, before_or_after="before")
             return func
@@ -35,7 +35,7 @@ class DecoratorAPI:
 
         if event_type not in EVENT_TYPES:
             raise ValueError(f"{event_type} not in {EVENT_TYPES}")
-        
+
         def _middleware_wrapper(func):
             self.register_middleware(func, event_type, before_or_after="after")
             return func
@@ -43,9 +43,13 @@ class DecoratorAPI:
         return _middleware_wrapper
 
     def middleware(self, event_type="all"):
-        """Middleware functions that are called before events for preprocessing. 
+        """Middleware functions that are called before events for preprocessing.
         This is deprecated and will be removed in the future. Use before_request instead"""
-        warn('Middleware method is deprecated. Use before_request instead', DeprecationWarning, stacklevel=2)
+        warn(
+            "Middleware method is deprecated. Use before_request instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if event_type not in EVENT_TYPES:
             raise ValueError(f"{event_type} not in {EVENT_TYPES}")
@@ -140,22 +144,22 @@ class Register_Handlers(DecoratorAPI):
 
         # call before request middleware
         request = self._call_middleware(request, event_type, before_or_after="before")
-        response = None 
+        response = None
 
         if event_type == "schedule":
             response = self.handlers["schedule"](request)
         if event_type == "pubsub":
-            response =  self.handlers["pubsub"](request, context)
+            response = self.handlers["pubsub"](request, context)
         if event_type == "storage":
-            response =  self.handlers["storage"](request, context)
+            response = self.handlers["storage"](request, context)
         if event_type == "route":
-            response =  self.handlers["route"](request)
+            response = self.handlers["route"](request)
         if event_type == "http":
-            response =  self.handlers["http"](request)
+            response = self.handlers["http"](request)
 
         if not response:
             raise ValueError(f"{event_type} not a valid event type")
-        
+
         # call after request middleware
         response = self._call_middleware(response, event_type, before_or_after="after")
         return response

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -3,6 +3,7 @@ from goblet.resources.routes import ApiGateway
 from goblet.resources.scheduler import Scheduler
 from goblet.resources.storage import Storage
 from goblet.resources.http import HTTP
+from warnings import warn
 
 import logging
 
@@ -17,8 +18,35 @@ class DecoratorAPI:
     registration function in the Register_Handlers class. For example _create_registration_function with type route will call
     _register_route"""
 
+    def before_request(self, event_type="all"):
+        """Function called before request for preeprocessing"""
+
+        if event_type not in EVENT_TYPES:
+            raise ValueError(f"{event_type} not in {EVENT_TYPES}")
+        
+        def _middleware_wrapper(func):
+            self.register_middleware(func, event_type, before_or_after="before")
+            return func
+
+        return _middleware_wrapper
+
+    def after_request(self, event_type="all"):
+        """Function called after request for postprocessing"""
+
+        if event_type not in EVENT_TYPES:
+            raise ValueError(f"{event_type} not in {EVENT_TYPES}")
+        
+        def _middleware_wrapper(func):
+            self.register_middleware(func, event_type, before_or_after="after")
+            return func
+
+        return _middleware_wrapper
+
     def middleware(self, event_type="all"):
-        """Middleware functions that are called before events for preprocessing"""
+        """Middleware functions that are called before events for preprocessing. 
+        This is deprecated and will be removed in the future. Use before_request instead"""
+        warn('Middleware method is deprecated. Use before_request instead', DeprecationWarning, stacklevel=2)
+
         if event_type not in EVENT_TYPES:
             raise ValueError(f"{event_type} not in {EVENT_TYPES}")
 
@@ -79,7 +107,7 @@ class DecoratorAPI:
     def _register_handler(self, handler_type, name, func, kwargs, options=None):
         raise NotImplementedError("_register_handler")
 
-    def register_middleware(self, func, event_type="all"):
+    def register_middleware(self, func, event_type="all", before_or_after="before"):
         raise NotImplementedError("register_middleware")
 
 
@@ -98,7 +126,10 @@ class Register_Handlers(DecoratorAPI):
             "storage": Storage(function_name, backend=backend),
             "http": HTTP(backend=backend),
         }
-        self.middleware_handlers = {}
+        self.middleware_handlers = {
+            "before": {},
+            "after": {},
+        }
         self.current_request = None
 
     def __call__(self, request, context=None):
@@ -107,21 +138,27 @@ class Register_Handlers(DecoratorAPI):
         self.request_context = context
         event_type = self.get_event_type(request, context)
 
-        # call middleware
-        request = self._call_middleware(request, event_type)
+        # call before request middleware
+        request = self._call_middleware(request, event_type, before_or_after="before")
+        response = None 
 
         if event_type == "schedule":
-            return self.handlers["schedule"](request)
+            response = self.handlers["schedule"](request)
         if event_type == "pubsub":
-            return self.handlers["pubsub"](request, context)
+            response =  self.handlers["pubsub"](request, context)
         if event_type == "storage":
-            return self.handlers["storage"](request, context)
+            response =  self.handlers["storage"](request, context)
         if event_type == "route":
-            return self.handlers["route"](request)
+            response =  self.handlers["route"](request)
         if event_type == "http":
-            return self.handlers["http"](request)
+            response =  self.handlers["http"](request)
 
-        raise ValueError(f"{event_type} not a valid event type")
+        if not response:
+            raise ValueError(f"{event_type} not a valid event type")
+        
+        # call after request middleware
+        response = self._call_middleware(response, event_type, before_or_after="after")
+        return response
 
     def __add__(self, other):
         for handler in self.handlers:
@@ -147,9 +184,9 @@ class Register_Handlers(DecoratorAPI):
             return "route"
         return None
 
-    def _call_middleware(self, event, event_type):
-        middleware = self.middleware_handlers.get("all", [])
-        middleware.extend(self.middleware_handlers.get(event_type, []))
+    def _call_middleware(self, event, event_type, before_or_after="before"):
+        middleware = self.middleware_handlers[before_or_after].get("all", [])
+        middleware.extend(self.middleware_handlers[before_or_after].get(event_type, []))
         for m in middleware:
             event = m(event)
 
@@ -191,10 +228,10 @@ class Register_Handlers(DecoratorAPI):
             return True
         return False
 
-    def register_middleware(self, func, event_type="all"):
-        middleware_list = self.middleware_handlers.get(event_type, [])
+    def register_middleware(self, func, event_type="all", before_or_after="before"):
+        middleware_list = self.middleware_handlers[before_or_after].get(event_type, [])
         middleware_list.append(func)
-        self.middleware_handlers[event_type] = middleware_list
+        self.middleware_handlers[before_or_after][event_type] = middleware_list
 
     def _register_http(self, name, func, kwargs):
         self.handlers["http"].register_http(func, kwargs=kwargs)

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -1,4 +1,6 @@
+from urllib import response
 from goblet import jsonify, Response, Goblet
+from unittest.mock import Mock
 
 
 class TestJsonify:
@@ -99,3 +101,41 @@ class TestDecoraters:
         assert app1.is_http()
         assert app2.is_http()
         assert not app3.is_http()
+
+
+    def test_before_request(self):
+        app = Goblet("test")
+
+        mock_request = Mock()
+        mock_request.path = "/test"
+        mock_request.method = "GET"
+
+
+        @app.before_request()
+        def before_request(request):
+            request.custom_header = "test"
+            return request
+        
+        @app.route("/test")
+        def dummy_function():
+            return app.current_request.custom_header
+     
+        assert  app(mock_request, {}) == "test"
+
+    def test_after_request(self):
+        app = Goblet("test")
+
+        mock_request = Mock()
+        mock_request.path = "/test"
+        mock_request.method = "GET"
+
+
+        @app.after_request()
+        def after_request(response):
+            return response + " after request"
+        
+        @app.route("/test")
+        def dummy_function():
+            return "test"
+     
+        assert app(mock_request, {}) == "test after request"

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -101,7 +101,6 @@ class TestDecoraters:
         assert app2.is_http()
         assert not app3.is_http()
 
-
     def test_before_request(self):
         app = Goblet("test")
 
@@ -109,17 +108,16 @@ class TestDecoraters:
         mock_request.path = "/test"
         mock_request.method = "GET"
 
-
         @app.before_request()
         def before_request(request):
             request.custom_header = "test"
             return request
-        
+
         @app.route("/test")
         def dummy_function():
             return app.current_request.custom_header
-     
-        assert  app(mock_request, {}) == "test"
+
+        assert app(mock_request, {}) == "test"
 
     def test_after_request(self):
         app = Goblet("test")
@@ -128,13 +126,12 @@ class TestDecoraters:
         mock_request.path = "/test"
         mock_request.method = "GET"
 
-
         @app.after_request()
         def after_request(response):
             return response + " after request"
-        
+
         @app.route("/test")
         def dummy_function():
             return "test"
-     
+
         assert app(mock_request, {}) == "test after request"

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -1,4 +1,3 @@
-from urllib import response
 from goblet import jsonify, Response, Goblet
 from unittest.mock import Mock
 


### PR DESCRIPTION
You can trigger custom middleware using the `before_request` and `after_request` decorators. These allow you to trigger custom functions before a request is passed to your request handler or do post processing on your responses. (closes #133 ) 

```
    @app.before_request()
    def add_db(request):
        app.g.db = "db"
        return request

    @app.after_request(event_type="pubsub")
    def add_header(response):
        response.headers["X-Custom"] = "custom header"
        return response
```