### PR TITLE
[Routes] cloudrun and apigateway route_type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ $ curl https://api.uc.gateway.dev/home
 
 > `goblet_entrypoint(app)`
 
+## Resources Supported
+
+#### Backends
+* cloudfunction
+* cloudrun
+
+#### Routing
+* api gateway
+* http
+
+#### Triggering
+* pubsub
+* scheduler
+* storage
+* eventarc
+
 ## Installation
 
 To install goblet, open an interactive shell and run:
@@ -122,17 +138,21 @@ This app will deploy an api with endpoint `/home`.
 
 ### Running Locally
 
-Running your functions locally for testing and debugging is easy to do with goblet. First set a local param in the goblet class
+Running your functions locally for testing and debugging is easy to do with goblet.
 
 ```python
 from goblet import Goblet
 
-app = Goblet(function_name="goblet_example", local='test')
+app = Goblet(function_name="goblet_example")
+goblet_entrypoint(app)
 
+@app.route('/home')
+def home():
+    return {"hello": "world"}
 ```
 
-Then run `goblet local test` and replace test with whatever variable you decide to use.
-Now you can hit your functions endpoint at `localhost:8080` with your routes.
+Then run `goblet local`
+Now you can hit your functions endpoint at `localhost:8080` with your routes. For example `localhost:8080/home`
 
 ### Deploying
 

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -90,6 +90,12 @@ The argument names for the view function must match the name of the captured arg
     def users(first, second):
         return {'first': first, 'second': second}
 
+By default routes are deployed to an api gateway. For cloudrun you have the option to use `route_type=cloudrun` to simply use the cloudrun 
+instance itself. The routes work the same as with an apigateway, but you would access the api via the cloudrun url instead of the api gateway url.
+
+.. code:: python 
+
+    app = Goblet(function_name="cloudrun-routing", routes_type="cloudrun", backend="cloudrun")
 
 Scheduled Jobs
 ^^^^^^^^^^^^^^

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 0)
+VERSION = (0, 7, 1)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -22,6 +22,7 @@ class Goblet(Register_Handlers):
         local="local",
         cors=None,
         client_versions=None,
+        routes_type="apigateway",
     ):
         self.function_name = GConfig().function_name or function_name
         self.client_versions = DEFAULT_CLIENT_VERSIONS
@@ -31,6 +32,7 @@ class Goblet(Register_Handlers):
             backend=backend,
             cors=cors,
             client_versions=self.client_versions,
+            routes_type=routes_type,
         )
         self.log = logging.getLogger(__name__)
         self.headers = {}

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -132,7 +132,12 @@ class Register_Handlers(DecoratorAPI):
     """Core Goblet logic. App entrypoint is the __call__ function which routes the request to the corresonding handler class"""
 
     def __init__(
-        self, function_name, backend="cloudfunction", cors=None, client_versions=None
+        self,
+        function_name,
+        backend="cloudfunction",
+        cors=None,
+        client_versions=None,
+        routes_type="apigateway",
     ):
         self.backend = backend
         if backend not in BACKEND_TYPES:
@@ -146,6 +151,7 @@ class Register_Handlers(DecoratorAPI):
                 cors=cors,
                 backend=backend,
                 versioned_clients=versioned_clients,
+                routes_type=routes_type,
             ),
             "schedule": Scheduler(
                 function_name, backend=backend, versioned_clients=versioned_clients

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+import pytest
 from goblet import Goblet, Response, jsonify
 from goblet.resources.routes import ApiGateway, CORSConfig
 from goblet.deploy import Deployer
@@ -196,6 +197,21 @@ class TestRoutes:
         assert post_gw["body"]["metadata"]["target"].endswith("goblet-routes")
         assert get_gw["body"]["state"] == "ACTIVE"
         assert get_gw["body"]["displayName"] == "goblet-routes"
+
+    def test_deploy_routes_type_cloudrun(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
+
+        gw = ApiGateway(name="test", routes_type="cloudrun", resources=[{}, {}])
+
+        assert gw.deploy() is None
+
+    def test_deploy_routes_type_cloudrun_with_incorrect_backend(self, monkeypatch):
+
+        ApiGateway(name="test", routes_type="cloudrun", resources=[{}, {}])
+        with pytest.raises(Exception):
+            ApiGateway.deploy()
 
     def test_destroy_routes(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")


### PR DESCRIPTION
Allow the option to have apigateway routes or cloudrun routes for the cloudrun backend. For cloudfunctions only api gateway will work with routes. These are accessed via the `routes_type` argument in Goblet. (closes #151 )

```
    app = Goblet(function_name="cloudrun-routing", routes_type="cloudrun", backend="cloudrun")
```