### PR TITLE
[Openapi] Custom type support

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -551,6 +551,45 @@ If you use a custom schema type you should create a schema class that inherits f
         
         return data
 
+    # Custom Marshmallow Fields
+    from marshmallow_enum import EnumField
+    from enum import Enum
+
+    def enum_to_properties(self, field, **kwargs):
+        """
+        Add an OpenAPI extension for marshmallow_enum.EnumField instances
+        """
+        if isinstance(field, EnumField):
+            return {'type': 'string', 'enum': [m.name for m in field.enum]}
+        return {}
+
+    app.handlers["route"].marshmallow_attribute_function = enum_to_properties
+
+    class StopLight(Enum):
+        green = 1
+        yellow = 2
+        red = 3
+
+    class TrafficStop(Schema):
+        light_color = EnumField(StopLight)
+
+
+    @app.route("/traffic")
+    def traffic() -> TrafficStop:
+        return TrafficStop().dump({"light_color":StopLight.green})
+
+    # Returns follow openapi spec
+    # definitions:
+    #   TrafficStop:
+    #     type: object
+    #     properties:
+    #       light_color:
+    #         type: string
+    #         enum:
+    #         - green
+    #         - yellow
+    #         - red
+
 .. _OPENAPI: https://swagger.io/specification/
 .. _GATEWAY: https://cloud.google.com/api-gateway/docs/openapi-overview
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -64,6 +64,44 @@ def points() -> List[Point]:
     point = Point().load({"lat": 0, "lng": 0})
     return [point]
 
+# Custom Marshmallow Fields
+from marshmallow_enum import EnumField
+from enum import Enum
+
+def enum_to_properties(self, field, **kwargs):
+    """
+    Add an OpenAPI extension for marshmallow_enum.EnumField instances
+    """
+    if isinstance(field, EnumField):
+        return {'type': 'string', 'enum': [m.name for m in field.enum]}
+    return {}
+
+app.handlers["route"].marshmallow_attribute_function = enum_to_properties
+
+class StopLight(Enum):
+    green = 1
+    yellow = 2
+    red = 3
+
+class TrafficStop(Schema):
+    light_color = EnumField(StopLight)
+
+
+@app.route("/traffic")
+def traffic() -> TrafficStop:
+    return TrafficStop().dump({"light_color":StopLight.green})
+
+# Returns follow openapi spec
+# definitions:
+#   TrafficStop:
+#     type: object
+#     properties:
+#       light_color:
+#         type: string
+#         enum:
+#         - green
+#         - yellow
+#         - red
 
 # Custom Backend
 @app.route("/custom_backend", backend="https://www.CLOUDRUN_URL.com/home")

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,2 @@
 goblet-gcp
+marshmallow_enum

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 2, 2)
+VERSION = (0, 7, 3)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -245,7 +245,6 @@ class TestOpenApiSpec:
         response_content = spec.spec["paths"]["/home"]["get"]["responses"]["200"][
             "schema"
         ]
-        dummy_schema = spec.spec["definitions"]
         assert response_content == {"$ref": "#/definitions/DummySchema"}
         assert (
             spec.spec["definitions"]["DummySchema"]["properties"]["flt"]["type"]

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -223,3 +223,35 @@ class TestOpenApiSpec:
         spec.add_route(route)
         entry = spec.spec["paths"]["/home"]["get"]
         assert entry["x-google-backend"]["address"] == "CLOUDRUN/URL"
+
+    def test_marshmallow_attribute_function(self):
+        def schema_typed() -> DummySchema:
+            return DummySchema()
+
+        def dummyschema_to_properties(self, field, **kwargs):
+            if isinstance(field, fields.Float):
+                return {"type": "custom"}
+            if isinstance(field, fields.Int):
+                return {"type": "custom"}
+            return {}
+
+        route = RouteEntry(schema_typed, "route", "/home", "GET")
+        spec = OpenApiSpec(
+            "test",
+            "xyz.cloudfunction",
+            marshmallow_attribute_function=dummyschema_to_properties,
+        )
+        spec.add_route(route)
+        response_content = spec.spec["paths"]["/home"]["get"]["responses"]["200"][
+            "schema"
+        ]
+        dummy_schema = spec.spec["definitions"]
+        assert response_content == {"$ref": "#/definitions/DummySchema"}
+        assert (
+            spec.spec["definitions"]["DummySchema"]["properties"]["flt"]["type"]
+            == "custom"
+        )
+        assert (
+            spec.spec["definitions"]["DummySchema"]["properties"]["id"]["type"]
+            == "custom"
+        )


### PR DESCRIPTION
Pass in function to `app.handlers["route"].marshmallow_attribute_function` that gets added to the marshmallow openapispec converter plugin

```# Custom Marshmallow Fields
from marshmallow_enum import EnumField
from enum import Enum

def enum_to_properties(self, field, **kwargs):
    """
    Add an OpenAPI extension for marshmallow_enum.EnumField instances
    """
    if isinstance(field, EnumField):
        return {'type': 'string', 'enum': [m.name for m in field.enum]}
    return {}

app.handlers["route"].marshmallow_attribute_function = enum_to_properties

class StopLight(Enum):
    green = 1
    yellow = 2
    red = 3

class TrafficStop(Schema):
    light_color = EnumField(StopLight)


@app.route("/traffic")
def traffic() -> TrafficStop:
    return TrafficStop().dump({"light_color":StopLight.green})

# Returns follow openapi spec
# definitions:
#   TrafficStop:
#     type: object
#     properties:
#       light_color:
#         type: string
#         enum:
#         - green
#         - yellow
#         - red
```