### PR TITLE
Skipping `tests` folder when deploying function

### DIFF
--- a/goblet/deploy.py
+++ b/goblet/deploy.py
@@ -246,7 +246,7 @@ class Deployer:
         self,
         dir,
         include=["*.py"],
-        exclude=["build", "docs", "examples", "test", "venv"],
+        exclude=["build", "docs", "examples", "test", "tests", "venv"],
     ):
         exclusion_set = set(exclude)
         globbed_files = []


### PR DESCRIPTION
Skipping  `tests`  folder when deploying function